### PR TITLE
Fix cec standby, by using kodi's executebuiltin instead of cec-client

### DIFF
--- a/default.py
+++ b/default.py
@@ -133,14 +133,7 @@ class SleepyWatchdog(XBMCMonitor):
     def sendCecCommand(self):
         if not self.sendCEC: return
         notifyLog('send standby command via CEC')
-        if platform.system() == 'Linux':
-            cec = subprocess.Popen('echo "standby 0" | cec-client -s', stdout=subprocess.PIPE, shell=True).communicate()
-        elif platform.system() == 'Windows':
-            cec = subprocess.Popen('echo standby 0 | cec-client.exe -s', stdout=subprocess.PIPE, shell=True).communicate()
-        else:
-            notifyLog('Platform not supported, don\'t send CEC command', xbmc.LOGERROR)
-            return
-        for retstr in cec: notifyLog(str(retstr).strip())
+        xbmc.executebuiltin('CECStandby')
 
     def runAddon(self):
         if xbmc.getCondVisibility('System.HasAddon(%s)' % (self.addon_id.split(',')[0])):


### PR DESCRIPTION
CEC Standby did not work, because the addon attempted to use external cec-client, which failed, because cec was already used by kodi itself (I am using Vero 4K box, in case if it matters).

Instead of checking for platform and running external process, it is easier to use inbuilt kodi command.